### PR TITLE
Issue #19 - Added About Modal and added necessary code to App.jsx - in progress w/o copy.

### DIFF
--- a/src/components/AboutModal.jsx
+++ b/src/components/AboutModal.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button } from 'react-bootstrap';
+
+const AboutModal = (props) => {
+	const {
+		onClick,
+		show,
+		hide,
+	} = props;
+	return (
+	<div>
+		<Button onClick={onClick} bsStyle="default">About Us</Button>
+
+		<Modal show={show} onHide={hide}>
+			<Modal.Header closeButton>
+				<Modal.Title>About Code for Greensboro</Modal.Title>
+			</Modal.Header>
+			<Modal.Body>
+				<h3>Rerum in aut aut debitis aliquid possimus qui.</h3>
+				<p>Quas maiores pariatur magnam dolores ut beatae id voluptas.</p>
+				<p>Culpa amet enim quaerat esse aut.</p>
+				<p>Consequatur voluptatem omnis fugit nisi. Soluta nulla provident repellat id corporis. Rem sit doloremque. Quo facere alias.</p>
+			</Modal.Body>
+			<Modal.Footer>
+				<Button onClick={hide} bsStyle="default">Close</Button>
+			</Modal.Footer>
+		</Modal>
+
+	</div>
+	);
+};
+
+AboutModal.PropTypes = {
+	onClick: PropTypes.func.isRequired,
+	hide: PropTypes.func.isRequired,
+	show: PropTypes.bool.isRequired,
+};
+
+module.exports = AboutModal;

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -7,6 +7,7 @@ import VoterInfoForm from './VoterInfoForm';
 import VerifyVoterInfo from './VerifyVoterInfo';
 import RegistrationInfoModal from './RegistrationInfoModal';
 import Header from './Header';
+import AboutModal from './AboutModal';
 
 class App extends Component {
   constructor() {
@@ -14,6 +15,7 @@ class App extends Component {
     this.state = {
       voterModalShow: true,
       regInfoModalShow: false,
+      aboutModalShow: false,
       firstName: '',
       lastName: '',
       voterInfo: [],
@@ -105,6 +107,20 @@ class App extends Component {
     });
   }
 
+  _handleShowAboutModal = () => {
+    this.setState({
+      aboutModalShow: true,
+    });
+    console.log('clicked');
+  }
+
+  _handleHideAboutModal = () => {
+    this.setState({
+      aboutModalShow: false,
+    });
+    console.log('closed');
+  }
+
   render() {
     const voterModalShow = () => this.setState({ voterModalShow: false });
     const regInfoModalShow = () => this.setState({ regInfoModalShow: false });
@@ -112,6 +128,7 @@ class App extends Component {
       this.state.layers.councilDist && this.state.layers.commissionerDist ?
         <div>
           <Header />
+          <AboutModal show={this.state.aboutModalShow} hide={this._handleHideAboutModal} onClick={this._handleShowAboutModal} />
           <div className="map">
             <MapContainer data={this.state.layers} voterAddress={this.state.voterAddress} />
             <VoterModal show={this.state.voterModalShow} onHide={voterModalShow}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
-I made a new component called AboutModal.jsx which renders a button that can be placed anywhere.  When you click the button it shows the About modal.  The modal is currently populated with lorem placeholder text.
-Added 'aboutModalShow' state to App.jsx to handle when AboutModal is shown and hidden.  False by default.
-App.jsx now imports AboutModal.jsx and renders it below the Header and above the Map as temporary placement.  Added 2 methods:
_handleShowAboutModal - When UI button is clicked it sets state to show modal.
_handleHideAboutModal - When button IN modal is clicked to close, sets state to close modal.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
[Issue #19](https://github.com/codeforgso/GoVote/issues/19)

## Motivation and Context
Provides requested functionality of adding a modal to provide information about Code for Greensboro.

## How Has This Been Tested?
Tested in browser.
Would like to add a Jest test, but didn't see Enzyme or any other tests created.. not sure if its ok to start adding tests etc?
This modal does have two methods which change state in App.jsx

## Screenshots (if appropriate):
<img width="1062" alt="aboutmodal" src="https://user-images.githubusercontent.com/26635668/32201560-3d72c148-bdae-11e7-9fbe-b26bdbc29ab4.png">


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
