### PR TITLE
Remove pg-native from dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1755,11 +1755,6 @@
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
-    "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-    },
     "bluebird": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
@@ -7204,15 +7199,6 @@
         "type-check": "0.3.2"
       }
     },
-    "libpq": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/libpq/-/libpq-1.8.7.tgz",
-      "integrity": "sha1-wt6xIeKPf4S9OyRRr/9otmY+dPk=",
-      "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.7.0"
-      }
-    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -7654,7 +7640,8 @@
     "nan": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "optional": true
     },
     "natives": {
       "version": "1.1.1",
@@ -8237,34 +8224,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pg-copy-streams/-/pg-copy-streams-1.2.0.tgz",
       "integrity": "sha1-ez+d7gtsX8IGj1nED6IY4MHXQkk="
-    },
-    "pg-native": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-native/-/pg-native-2.2.0.tgz",
-      "integrity": "sha1-vIR1b07L9gD/fLSOpYVBQYMM8eQ=",
-      "requires": {
-        "libpq": "1.8.7",
-        "pg-types": "1.12.1",
-        "readable-stream": "1.0.31"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.31",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
-          "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
     },
     "pg-pool": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "path": "^0.12.7",
     "pg": "^7.1.0",
     "pg-copy-streams": "^1.2.0",
-    "pg-native": "^2.2.0",
     "postcss-flexbugs-fixes": "^3.2.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed pg-native from dependencies.

## Description
<!--- Describe your changes in detail -->
`npm uninstall --save pg-native`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#36 Remove pg-native from module dependencies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes errors with `npm install`/`yarn install`.
Does not require developers to unnecessarily install PostgresSQL on their dev machine.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a my mac, I uninstalled postgres/libpq and ran `npm install` against a version of the project with pg-native in the dependency. This raised the node-gyp/libpq errors.
Ran `npm uninstall --save pg-native` then ran `npm install`. No issues were raised.
Repeated the same steps on an Ubuntu machine with the same results.

