### PR TITLE
Adding test for configuration via ebextensions

### DIFF
--- a/.ebextensions-dev/01_ssl.config
+++ b/.ebextensions-dev/01_ssl.config
@@ -1,0 +1,7 @@
+files:
+  /tmp/ssl.conf:
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 
 script:
   - npm run build
+  - [ -d ".ebextensions-$TRAVIS_BRANCH" ] && cp -r .ebextensions-$TRAVIS_BRANCH build/.ebextensions
   - cd build; zip -r ../build.zip ./; cd -
 
 deploy:


### PR DESCRIPTION
Testing a per-environment ebextensions setup to configure SSL/crons for the EB deployments.  This should just create a new file `/tmp/ssl.conf` in the dev environment.
