### PR TITLE
Configure docker-compose.yml to use .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Interested in contributing? Please read our [contributing guide](./.github/CONTR
 
 ## Development Site
 A live version of our dev branch can be seen [here](http://govotegso-dev-1.us-east-1.elasticbeanstalk.com/)
+
+## Steps to Deploy via Docker
+
+In order to deploy this application, you will need to create a .env file and copy to it the contents of the sample.env file. Make sure to update the variable values with the intended values.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,10 @@ services:
     volumes:
       - .:/opt/app
     environment:
-      - DB_HOST=db
-      - DB_NAME=GoVoteGSO
-      - DB_USER=govoteuser
-      - DB_PASS=password
-      - DB_PORT=5432
-      - DB_TABLE=guilfordvoters
-      - NODE_ENV=development
+      - DB_HOST=${DB_HOST}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASS=${DB_PASS}
+      - DB_PORT=${DB_PORT}
+      - DB_TABLE=${DB_TABLE}
+      - NODE_ENV=${NODE_ENV}

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,7 @@
+DB_HOST=<databaseHost>
+DB_NAME=<databaseName>
+DB_USER=<databaseUser>
+DB_PASS=<databasePassword>
+DB_PORT=<databasePort>
+DB_TABLE=<databaseTable>
+NODE_ENV=<nodeEnvironment>


### PR DESCRIPTION
I moved the environment variables out of the docker-compose.yml and added steps for how to update .env file

## Description
I pulled out the pre-defined environment variable values in the docker-compose.yaml and created a sample.env for users to understand how to set them when deploying. I also added instructions to the readme on how to deploy with these changes.

## Related Issue
#126 

## Motivation and Context
This change allows for reusability and is more secure than storing passwords and ports in the public repository code.

## How Has This Been Tested?
I ran a sample deployment and made sure it still deploys.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (I didn't have any to add)
- [x] All new and existing tests passed.
