### PR TITLE
Better `polling_places` data

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -5,4 +5,4 @@ DB_USER=govoteuser
 DB_PASS=govotepassword
 DB_PORT=5432
 VOTER_URL=https://dl.ncsbe.gov/data/ncvoter41.zip
-POLLING_PLACE_URL=https://s3.amazonaws.com/dl.ncsbe.gov/ENRS/2019_05_14/polling_place_20190514.csv
+POLLING_PLACE_URL=https://s3.amazonaws.com/dl.ncsbe.gov/ENRS/2019_11_05/polling_place_20191105.csv

--- a/server/bin/etl.js
+++ b/server/bin/etl.js
@@ -29,6 +29,7 @@ class StreamCleaner extends Transform {
     const transformedChunk = chunk
       .toString()
       .replace(/\uFFFD/g, '')
+      .replace(/[^\t\r\n -~]+/g, '')
       .replace(/\0/g, '');
 
     this.push(transformedChunk);

--- a/server/server.js
+++ b/server/server.js
@@ -35,15 +35,18 @@ router.get('/api/:fn/:ln', async (req, res) => {
   const pollingTable = 'polling_places';
   const query = `SELECT ${voterTable}.*,
     polling_place_id,
-    polling_place_name,
-    precinct_name as "polling_place_precinct_name",
-    house_num     as "polling_place_house_num",
-    street_name   as "polling_place_street_name",
-    city          as "polling_place_city",
-    state         as "polling_place_state",
-    zip           as "polling_place_zip"
+    COALESCE(
+      polling_place_name, 'Unable to lookup polling place name'
+    ) AS polling_place_name,
+    COALESCE(precinct_name, '') AS polling_place_precinct_name,
+    COALESCE(house_num, '')     AS polling_place_house_num,
+    COALESCE(street_name, '')   AS polling_place_street_name,
+    COALESCE(city, '')          AS polling_place_city,
+    COALESCE(state, '')         AS polling_place_state,
+    COALESCE(zip, '')           AS polling_place_zip
     FROM ${voterTable}
-    INNER JOIN ${pollingTable} ON ${voterTable}.precinct_abbrv = ${pollingTable}.precinct_name 
+    LEFT OUTER JOIN ${pollingTable}
+      ON ${voterTable}.precinct_abbrv = ${pollingTable}.precinct_name
       AND ${voterTable}.county_desc = ${pollingTable}.county_name
     WHERE voter_status_desc NOT LIKE 'REMOVED'
       AND first_name ilike $1::text


### PR DESCRIPTION
The current ETL process is not populating polling places for Guilford County.  We are using an `INNER JOIN` on the `polling_places` table in our query, thus returning zero results for lookups for voter registration information.

Also, the data for the `POLLING_PLACE_URL` in the `sample.env` file was a little outdated, so I updated the URL.

Also, the CSV data had garbage characters that was causing the import to quit (without error) before it reached lines for Guilford County.  I added a new regex to clean it up before import.

This PR fixes the ETL process so we get results for Guilford County lookups.

## Description
Return results even when `polling_places` record cannot be found.

Use `LEFT OUTER JOIN` vs `INNER JOIN` on `polling_places` table
 * Allows you to at least get results from the `voters` table to the UI

Use `COALESCE()` to provide alternate results when `NULL`

Update `POLLING_PLACE_URL` to https://s3.amazonaws.com/dl.ncsbe.gov/ENRS/2019_11_05/polling_place_20191105.csv

Add this regex/replace: `.replace(/[^\t\r\n -~]+/g, '')` 

## Screenshots (if appropriate):
Polling place data when there's no record found:
<img width="514" alt="Screen Shot 2020-02-11 at 6 59 08 PM" src="https://user-images.githubusercontent.com/280902/74290690-98602d00-4d00-11ea-9cef-556906b43f4e.png">


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
