### PR TITLE
Focus to first name field on load

### DIFF
--- a/client/src/components/VoterRegLookup.jsx
+++ b/client/src/components/VoterRegLookup.jsx
@@ -104,6 +104,7 @@ function VoterRegForm({ resetVoter, voter, setVoterList }) {
       >
         <ControlLabel>First Name</ControlLabel>
         <FormControl
+          autoFocus
           type="text"
           name="firstName"
           onChange={handleInputChange(firstName, setFirstName)}


### PR DESCRIPTION

## Description
created a ref const called focusRef using useRef(null)
passed focusRef as inputRef to FormControl component
called focusRef.current.focus() in useEffect hook for VoterRegLookup component

## Related Issue
https://github.com/codeforgso/GoVote/issues/161

## Motivation and Context
Best practice for accessibility and ease of use. Used ref method rather than just setting autoFocus property on FormControl based on screen reader usage recommendations. 

## How Has This Been Tested?
Loaded in local dev environment and tested tabbing through and refreshing page. Consistent in Chrome. Not tested in other browsers, but I believe the implementation I used is cross-browser consistent. 

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
