### PR TITLE
buried candidate info access closes #186

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,22 +1,23 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { Row, Col, Button, Well } from 'react-bootstrap';
-import PropTypes from 'prop-types';
+import React from "react";
+import { Link } from "react-router-dom";
+import { Row, Col, Button, Well } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 const Card = ({ title, body, btnText, linkTo, style = {} }) => (
   <Well
-    style={Object.assign({
-      minHeight: '300px',
-    }, style)}
+    style={Object.assign(
+      {
+        minHeight: "300px",
+      },
+      style
+    )}
     bsStyle="primary"
     bsSize="large"
   >
     <h2>{title}</h2>
     <p>{body}</p>
     <Link to={linkTo}>
-      <Button bsStyle="primary">
-        {btnText}
-      </Button>
+      <Button bsStyle="primary">{btnText}</Button>
     </Link>
   </Well>
 );
@@ -55,14 +56,6 @@ const Home = () => (
           body="It's election day and you're unsure what to do! Find out more about what to expect, reporting polling place issues, and how to find your polling place here"
           btnText="Learn more about election day"
           linkTo="/election-day"
-        />
-      </Col>
-      <Col md={6} lg={4} sm={6}>
-        <Card
-          title="Find Out Who Your Candidates Are"
-          body="Confused about who you are voting for? To find your sample ballot click below"
-          btnText="Find your candidates &amp; sample ballot"
-          linkTo="/candidates"
         />
       </Col>
       <Col md={6} lg={4} sm={6}>

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -58,6 +58,7 @@ const Home = () => (
           linkTo="/election-day"
         />
       </Col>
+      {/* deleted candidate info for 2020v1 component per https://github.com/codeforgso/GoVote/pull/190*/}
       <Col md={6} lg={4} sm={6}>
         <Card
           title="About GoVoteGSO &amp; CodeForGSO"

--- a/client/src/pages/routes.js
+++ b/client/src/pages/routes.js
@@ -1,39 +1,39 @@
-import About from './About';
-import CanIVote from './CanIVote';
-import WhereAndWhen from './WhereAndWhen';
-import DayOfInfo from './DayOfInfo';
-import Candidates from './Candidates';
+import About from "./About";
+import CanIVote from "./CanIVote";
+import WhereAndWhen from "./WhereAndWhen";
+import DayOfInfo from "./DayOfInfo";
+//import Candidates from './Candidates';
 
 const routes = [
   {
-    to: '/about',
+    to: "/about",
     component: About,
-    label: 'About',
-    labelLong: 'About the GoVoteGSO project',
+    label: "About",
+    labelLong: "About the GoVoteGSO project",
   },
   {
-    to: '/can-i-vote',
+    to: "/can-i-vote",
     component: CanIVote,
-    label: 'Can I Vote?',
+    label: "Can I Vote?",
   },
   {
-    to: '/where-and-when',
+    to: "/where-and-when",
     component: WhereAndWhen,
-    label: 'Where and When',
-    labelLong: 'Where and When To Vote',
+    label: "Where and When",
+    labelLong: "Where and When To Vote",
   },
   {
-    to: '/election-day',
+    to: "/election-day",
     component: DayOfInfo,
-    label: 'Election Day',
-    labelLong: 'It\'s Election Day, What Do I Do?',
+    label: "Election Day",
+    labelLong: "It's Election Day, What Do I Do?",
   },
-  {
+  /*{
     to: '/candidates',
     component: Candidates,
     label: 'Candidates',
     labelLong: 'Who Are The Candidates?',
-  },
+  },*/
 ];
 
 export default routes;

--- a/client/src/pages/routes.js
+++ b/client/src/pages/routes.js
@@ -28,12 +28,7 @@ const routes = [
     label: "Election Day",
     labelLong: "It's Election Day, What Do I Do?",
   },
-  /*{
-    to: '/candidates',
-    component: Candidates,
-    label: 'Candidates',
-    labelLong: 'Who Are The Candidates?',
-  },*/
+  // deleted route to Candidate Info for 2020v1 per https://github.com/codeforgso/GoVote/pull/190
 ];
 
 export default routes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
commented out route to candidate in routes.js
removed candidate info card from home.jsx

## Related Issue
https://github.com/codeforgso/GoVote/issues/186

## Motivation and Context
Triage of features we have time to complete for MVP in 2020 election season. Left the bones behind to revisit later. 

## How Has This Been Tested?
spun up locally and confirmed candidate card gone from home page, no errors. 

## Screenshots (if appropriate):


