### PR TITLE
PR185 Force SSL in staging/production

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,17 @@ const path = require('path');
 const app = express();
 const router = new Router();
 
+// https://webdva.github.io/how-to-force-express-https-tutorial/
+app.use((req, res, next) => {
+  if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging') {
+    if (req.headers['x-forwarded-proto'] !== 'https')
+      return res.redirect('https://' + req.headers.host + req.url);
+    else
+       return next();
+  } else
+    return next();
+});
+
 if (process.env.NODE_ENV !== 'production') {
   dotenv.config({ path: '../.env' });
 }


### PR DESCRIPTION
# Force SSL

## Description
In production / staging (where we have SSL setup), create a redirect for non-SSL requests (http://) to SSL requests (https://)

## Motivation and Context
Secure it better in general, but this also has to do with the way that requests for http://govotegso.org will direct to http://www.govotegso.org.  After this change, requests for http://www.govotegso.org will redirect to https://www.govotegso.org.

## How Has This Been Tested?
Will have to test this out in staging, where we have SSL setup before promoting to production (before merging to `master` branch).

