### PR TITLE
Do not create tables or run ETL process on deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: cd server/ && npm install && node ./bin/create-tables.js && node ./bin/etl.js
+release: cd server/ && npm install
 web: npm run prod-server


### PR DESCRIPTION
## Description
Do not create tables or run ETL process on deploy

Closes #178

## Motivation and Context
We don't need to waste time with an ETL job on deploy b/c it is scheduled to run nightly now.

## How Has This Been Tested?
Merging to dev will test this out
