### PR TITLE
Add preventDefault to voter lookup submit

### DIFF
--- a/client/src/components/VoterRegLookup.jsx
+++ b/client/src/components/VoterRegLookup.jsx
@@ -49,7 +49,8 @@ function VoterRegForm({ resetVoter, voter, setVoterList }) {
     return isValid;
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e) => {
+    e.preventDefault()
     if (validateInput()) {
       try {
         setIsLoading(true);
@@ -58,7 +59,7 @@ function VoterRegForm({ resetVoter, voter, setVoterList }) {
         resetVoter();
         setVoterList(voterList ? voterList : []);
         setNoVotersFound(!voterList.length);
-      } catch (e) {
+      } catch (error) {
         setFormErrors([
           'Error retrieving voter registration information. Please try again',
         ]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add `e.preventDefault` to voter lookup form submit.

By default HTML forms will try to submit data to the server, and refresh the page. (You don't really see this behavior in most modern development anymore, but in ye-olden-days of the web this was standard). You can prevent the the form from submitting data to the server and refreshing the page by using `e.preventDefault`, where `e` is the form submit event in your handler function

MDN for prevent default: https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#188 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

PS: Whoever setup the dev environment for this project was an idiot ;)