### PR TITLE
use react router link instead of a tag for about link

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -69,7 +69,7 @@ const Home = () => (
       {/* deleted candidate info for 2020v1 component per https://github.com/codeforgso/GoVote/pull/190*/}
     </Row>
     <div>
-      <h3><a href="/about">About GoVoteGSO &amp; CodeForGSO</a></h3>
+      <h3><Link to="/about">About GoVoteGSO &amp; CodeForGSO</Link></h3>
       <p>Learn more about this website, open source software, civic tech, and CodeForGreensboro</p>
     </div>
   </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On staging, the link for `About GoVoteGSO & CodeForGSO` sends you to `https://staging.govotegso.org/about` or `https://staging.govotegso.org/about#/`. I can't replicate the bug locally, but I believe it's because we're using `<a>` instead of `<Link>`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/codeforgso/GoVote/issues/206

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
