### PR TITLE
Fix broken link to candidate information

### DIFF
--- a/client/src/components/CanIVoteRegistered.jsx
+++ b/client/src/components/CanIVoteRegistered.jsx
@@ -5,10 +5,9 @@ import { Link } from 'react-router-dom';
 
 const CanIVoteRegistered = ({ showHeader = false }) => (
   <div>
-    { showHeader && <h2>You are registered!</h2> }
+    { showHeader && <h2>You are registered!</h2>}
     <ListGroup>
       <ListGroupItem><Link to="/where-and-when">See Where &amp; When to Vote</Link></ListGroupItem>
-      <ListGroupItem><Link to="/candidates">See who the candidates are</Link></ListGroupItem>
     </ListGroup>
   </div>
 );

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -144,8 +144,14 @@ button {
 
 
 .header {
-  /* This shorthand also overrides default Bootstrap gradient)*/
+  /* This shorthand also overrides default Bootstrap gradient. Since we're changing the background color,
+     we also need to remove the border since it was set to the same color as the previous background color + remove
+     rounded corners at the top so no color is showing
+   */
   background: #283944;
+  border: none;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
 }
 
 .header__brand {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
* Remove link pointing registered voters to their candidates
* Remove border from nav


## Description
1. The link pointing voters to the candidates was broken, so we simply eliminated the component.
2. The Navbar used to look like this:
![image](https://user-images.githubusercontent.com/2475615/94878373-23766a80-042b-11eb-8002-9cb8a2767336.png)

It now looks like this:
<img width="202" alt="image" src="https://user-images.githubusercontent.com/2475615/94878412-4012a280-042b-11eb-87fb-de6c9b9e5688.png">

## Related Issue
Closes #204 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
